### PR TITLE
replace sublime-tern with tern_for_sublime

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Plugins:
 
 - [JsFormat](https://github.com/jdc0589/JsFormat) — a JavaScript formatting plugin. It uses the command-line/python-module JavaScript formatter from http://jsbeautifier.org to format whole js or json files, or the selected portion(s).
 - [CoffeeScript](https://github.com/Xavura/CoffeeScript-Sublime-Plugin) — syntax highlighting and checking, commands, shortcuts, snippets, compilation and more.
-- [TernJS](https://github.com/emmetio/sublime-tern) — a JavaScript type inference engine integration.
+- [TernJS](https://github.com/ternjs/tern_for_sublime) — a JavaScript type inference engine integration.
 
 ### Client Side Profile
 


### PR DESCRIPTION
sublime-tern is [deprecated](https://github.com/emmetio/sublime-tern#deprecated-use-tern-for-sublime-instead) in favor of tern_for_sublime